### PR TITLE
* Switch docs to NuGet-versioned publishing

### DIFF
--- a/.github/SETUP_GITHUB_PAGES.md
+++ b/.github/SETUP_GITHUB_PAGES.md
@@ -1,13 +1,13 @@
 # Setting Up Automated DocFX Documentation Builds with GitHub Actions
 
-This guide explains how to set up automated documentation builds using the GitHub Actions workflow included in this repository.
+This guide explains how to set up documentation validation and NuGet-aligned publishing with GitHub Actions.
 
 ## Overview
 
-The workflow (`.github/workflows/build.yml`) automatically:
-- **Builds** the DocFX documentation when changes are pushed
-- **Deploys** to GitHub Pages on pushes to main/master branches
-- **Validates** documentation on pull requests (without deploying)
+| Workflow | Purpose |
+|----------|---------|
+| `.github/workflows/build.yml` | Validates DocFX on push/PR (`v/local-dev/` only; no Pages deploy) |
+| `.github/workflows/publish-docs-version.yml` | Builds one NuGet version, merges into `docs-versions`, deploys Pages |
 
 ## Setup Instructions
 
@@ -21,103 +21,38 @@ The workflow (`.github/workflows/build.yml`) automatically:
 
 ### 2. Configure Repository Permissions
 
-The workflow requires specific permissions to deploy to GitHub Pages:
+Publishing needs write access for the `docs-versions` branch and Pages:
 
 1. Go to **Settings** → **Actions** → **General**
 2. Scroll down to **Workflow permissions**
 3. Ensure **Read and write permissions** is selected
-4. Check **Allow GitHub Actions to create and approve pull requests** (if needed)
-5. Click **Save**
+4. Click **Save**
 
-### 3. Trigger the Workflow
+### 3. Publish a documentation version
 
-The workflow will automatically run when:
-- Code is pushed to `main`, `master`
-- A pull request is opened targeting `main` or `master`
-- Manually triggered via the **Actions** tab
+**Manual:** Actions → **Publish Docs Version** → provide `channel`, `version`, `standard_ref`, and optional `extended_ref` / `line`.
 
-To manually trigger:
-1. Go to the **Actions** tab in your repository
-2. Select **Build and Deploy DocFX Documentation** from the left sidebar
-3. Click **Run workflow** → **Run workflow**
+**Automated (Standard-Toolkit):** after NuGet push, `repository_dispatch` with type `docs-publish`. Requires a PAT secret in Standard-Toolkit with `actions:write` on this repo. Documented in [Publish Docs From Toolkit](../Source/Help/DocFX/articles/Contributing/Workflows/PublishDocsFromToolkit.md).
 
 ### 4. Access Your Documentation
 
-Once the workflow completes successfully:
-- Your documentation will be available at: `https://<username>.github.io/<repository-name>/`
-- For example: `https://krypton-suite.github.io/Standard-Toolkit-Online-Help/`
+Once a publish completes:
 
-**Important**: The documentation is served from the root of the GitHub Pages site, NOT from `/Source/Help/Output/`. The workflow automatically deploys the contents of `Source/Help/Output` to the root of your GitHub Pages site.
+- Site: `https://<username>.github.io/<repository-name>/`
+- Example: `https://krypton-suite.github.io/Standard-Toolkit-Online-Help/`
+- Version trees: `/v/<PackageVersion>/`
+- Catalog: `/versions.json`
 
-## Workflow Details
+## Persistence (`docs-versions` branch)
 
-### Build Job
-- Runs on: Windows (latest)
-- Installs: .NET SDK 8.x and DocFX
-- Builds: Documentation from `Source/Help/DocFX`
-- Outputs: To `Source/Help/Output`
+GitHub Pages replaces the whole site each deploy. Historical Stable/LTS trees are stored on the long-lived `docs-versions` branch and re-deployed with each publish. Canary/Nightly keep only the latest tree of that channel.
 
-### Deploy Job
-- Runs on: Ubuntu (latest)
-- Triggers: Only on pushes to main/master branches
-- Action: Deploys built documentation to GitHub Pages
+## Validation workflow
 
-## Customization
-
-### Change Target Branches
-
-Edit `.github/workflows/build.yml` to modify which branches trigger the workflow:
-
-```yaml
-on:
-  push:
-    branches:
-      - main
-      - your-branch-name
-```
-
-### Disable Automatic Deployment
-
-To build without deploying, remove or comment out the `deploy` job section in the workflow file.
-
-### Add Build Steps
-
-You can add additional steps before or after the DocFX build, such as:
-- Running tests
-- Validating links
-- Checking for broken references
+`build.yml` checks out toolkit `master` siblings and builds `site/v/local-dev/` to catch DocFX/article regressions. It does **not** update `docs-versions` or Pages.
 
 ## Troubleshooting
 
-### Build Fails
-- Check the **Actions** tab for detailed error logs
-- Ensure `docfx.json` is valid
-- Verify all referenced files and paths exist
-
-### Deployment Fails
-- Ensure GitHub Pages is enabled (see step 1)
-- Check workflow permissions (see step 2)
-- Verify the Pages source is set to "GitHub Actions"
-
-### Documentation Not Updating
-- Check if the workflow completed successfully in the Actions tab
-- Clear your browser cache
-- Wait a few minutes for GitHub Pages to update
-
-## Additional Resources
-
-- [DocFX Documentation](https://dotnet.github.io/docfx/)
-- [GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [GitHub Pages Documentation](https://docs.github.com/en/pages)
-- [Issue #22](https://github.com/Krypton-Suite/Standard-Toolkit-Online-Help/issues/22)
-
-## Support
-
-If you encounter issues:
-1. Check the Actions logs for detailed error messages
-2. Review the [DocFX troubleshooting guide](https://dotnet.github.io/docfx/docs/faq.html)
-3. Open an issue in the repository with:
-   - Error messages from the Actions log
-   - Steps to reproduce the problem
-   - Expected vs. actual behavior
-
+- Missing Pages after push to main: expected — use **Publish Docs Version** (or wait for toolkit dispatch).
+- Dropdown empty: `versions.json` has no entries until the first successful publish.
+- Canary/Nightly disappeared: by design when a newer package of that channel is published.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
-name: Build and Deploy DocFX Documentation
+name: Validate DocFX Documentation
+
+# PR / push validation only. Published site versions are deployed by
+# publish-docs-version.yml (NuGet-aligned trees on the docs-versions branch).
 
 on:
   push:
@@ -13,28 +16,15 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
+  group: validate-docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  validate:
     runs-on: windows-latest
     timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - branch: master
-            slug: master
-          - branch: alpha
-            slug: alpha
-          - branch: V105-LTS
-            slug: v105-lts
-
     steps:
       - name: Enable long path support on Windows
         if: runner.os == 'Windows'
@@ -44,20 +34,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: Standard-Toolkit-Online-Help
-          fetch-depth: 0
 
       - name: Checkout Standard-Toolkit
         uses: actions/checkout@v4
         with:
           repository: Krypton-Suite/Standard-Toolkit
-          ref: ${{ matrix.branch }}
+          ref: master
           path: Standard-Toolkit
 
       - name: Checkout Extended-Toolkit
         uses: actions/checkout@v4
         with:
           repository: Krypton-Suite/Extended-Toolkit
-          ref: ${{ matrix.branch }}
+          ref: master
           path: Extended-Toolkit
 
       - name: Setup .NET
@@ -70,94 +59,23 @@ jobs:
       - name: Install DocFX
         run: dotnet tool install -g docfx
 
-      - name: Build Documentation (${{ matrix.branch }})
+      - name: Build disposable local-dev tree
         shell: pwsh
         run: |
           & "Standard-Toolkit-Online-Help/Scripts/Build-VersionedDocs.ps1" `
-            -Branch "${{ matrix.branch }}" `
+            -LocalDev `
             -OutputRoot (Join-Path $env:GITHUB_WORKSPACE "site") `
             -UseSiblings `
             -SkipClone
 
-      - name: Diagnose output directory
-        if: always()
+      - name: Verify output
         shell: pwsh
         run: |
-          $slug = "${{ matrix.slug }}"
-          $root = Join-Path $env:GITHUB_WORKSPACE "site"
-          Write-Host "GITHUB_WORKSPACE=$env:GITHUB_WORKSPACE"
-          Write-Host "Expected: $(Join-Path $root $slug)"
-          if (Test-Path $root) {
-            Get-ChildItem -Force $root -Recurse -Depth 2 | Select-Object -First 80 FullName
-          }
-          else {
-            Write-Host "site/ does not exist"
-          }
-          $index = Join-Path $root "$slug/index.html"
+          $index = Join-Path $env:GITHUB_WORKSPACE "site\v\local-dev\index.html"
           if (-not (Test-Path $index)) {
             Write-Host "::error::Missing $index"
+            Get-ChildItem -Force (Join-Path $env:GITHUB_WORKSPACE "site") -Recurse -Depth 3 |
+              Select-Object -First 80 FullName
+            exit 1
           }
-
-      - name: Upload version artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs-${{ matrix.slug }}
-          path: site/${{ matrix.slug }}
-          if-no-files-found: error
-
-  merge:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Download version artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: docs-*
-          path: combined
-
-      - name: Assemble site
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p site
-          for dir in combined/docs-*; do
-            slug="${dir#combined/docs-}"
-            echo "Copying $dir -> site/$slug"
-            mkdir -p "site/$slug"
-            cp -a "$dir/." "site/$slug/"
-          done
-          printf '%s\n' \
-            '<!DOCTYPE html>' \
-            '<html lang="en">' \
-            '<head>' \
-            '  <meta charset="utf-8" />' \
-            '  <meta http-equiv="refresh" content="0; url=master/" />' \
-            '  <title>Krypton Toolkit Documentation</title>' \
-            '  <link rel="canonical" href="master/" />' \
-            '  <script>location.replace("master/");</script>' \
-            '</head>' \
-            '<body>' \
-            '  <p>Redirecting to <a href="master/">master</a> documentation…</p>' \
-            '</body>' \
-            '</html>' > site/index.html
-          ls -la site
-          test -d site/master
-          test -d site/alpha
-          test -d site/v105-lts
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: merge
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          Write-Host "OK: $index"

--- a/.github/workflows/publish-docs-version.yml
+++ b/.github/workflows/publish-docs-version.yml
@@ -1,0 +1,243 @@
+name: Publish Docs Version
+
+# Builds one NuGet-aligned DocFX tree into docs-versions (v/<version>/),
+# prunes previous canary/nightly trees, updates versions.json, and deploys Pages.
+
+on:
+  repository_dispatch:
+    types: [docs-publish]
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'stable | lts | canary | nightly'
+        required: true
+        type: choice
+        options:
+          - stable
+          - lts
+          - canary
+          - nightly
+      version:
+        description: 'Exact NuGet PackageVersion (e.g. 110.26.11.328)'
+        required: true
+        type: string
+      standard_ref:
+        description: 'Standard-Toolkit SHA, tag, or branch'
+        required: true
+        type: string
+      extended_ref:
+        description: 'Extended-Toolkit SHA/tag/branch (defaults to standard_ref)'
+        required: false
+        type: string
+      line:
+        description: 'Optional LTS line name (e.g. V105-LTS)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: publish-docs-version
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    timeout-minutes: 180
+    steps:
+      - name: Resolve publish inputs
+        id: meta
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "repository_dispatch") {
+            $channel = "${{ github.event.client_payload.channel }}"
+            $version = "${{ github.event.client_payload.version }}"
+            $standardRef = "${{ github.event.client_payload.standard_ref }}"
+            $extendedRef = "${{ github.event.client_payload.extended_ref }}"
+            $line = "${{ github.event.client_payload.line }}"
+          }
+          else {
+            $channel = "${{ inputs.channel }}"
+            $version = "${{ inputs.version }}"
+            $standardRef = "${{ inputs.standard_ref }}"
+            $extendedRef = "${{ inputs.extended_ref }}"
+            $line = "${{ inputs.line }}"
+          }
+
+          if ([string]::IsNullOrWhiteSpace($channel)) { throw "channel is required" }
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "version is required" }
+          if ([string]::IsNullOrWhiteSpace($standardRef)) { throw "standard_ref is required" }
+          if ([string]::IsNullOrWhiteSpace($extendedRef)) { $extendedRef = $standardRef }
+          if ([string]::IsNullOrWhiteSpace($line)) { $line = "" }
+
+          "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "standard_ref=$standardRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "extended_ref=$extendedRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "line=$line" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Publishing docs: channel=$channel version=$version standard=$standardRef extended=$extendedRef line=$line"
+
+      - name: Enable long path support on Windows
+        run: git config --global core.longpaths true
+
+      - name: Checkout documentation (source)
+        uses: actions/checkout@v4
+        with:
+          path: Standard-Toolkit-Online-Help
+          fetch-depth: 0
+
+      - name: Checkout Standard-Toolkit
+        uses: actions/checkout@v4
+        with:
+          repository: Krypton-Suite/Standard-Toolkit
+          ref: ${{ steps.meta.outputs.standard_ref }}
+          path: Standard-Toolkit
+
+      - name: Checkout Extended-Toolkit
+        uses: actions/checkout@v4
+        with:
+          repository: Krypton-Suite/Extended-Toolkit
+          ref: ${{ steps.meta.outputs.extended_ref }}
+          path: Extended-Toolkit
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x
+            10.x
+
+      - name: Install DocFX
+        run: dotnet tool install -g docfx
+
+      - name: Build version tree
+        shell: pwsh
+        run: |
+          $out = Join-Path $env:GITHUB_WORKSPACE "built"
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          $args = @{
+            Channel      = "${{ steps.meta.outputs.channel }}"
+            Version      = "${{ steps.meta.outputs.version }}"
+            StandardRef  = "${{ steps.meta.outputs.standard_ref }}"
+            ExtendedRef  = "${{ steps.meta.outputs.extended_ref }}"
+            OutputRoot   = $out
+            UseSiblings  = $true
+            SkipClone    = $true
+          }
+          $line = "${{ steps.meta.outputs.line }}"
+          if (-not [string]::IsNullOrWhiteSpace($line)) {
+            $args['Line'] = $line
+          }
+          & "Standard-Toolkit-Online-Help/Scripts/Build-VersionedDocs.ps1" @args
+
+      - name: Prepare docs-versions working tree
+        shell: pwsh
+        run: |
+          $repo = Join-Path $env:GITHUB_WORKSPACE "Standard-Toolkit-Online-Help"
+          $persist = Join-Path $env:GITHUB_WORKSPACE "docs-versions-site"
+          New-Item -ItemType Directory -Force -Path $persist | Out-Null
+
+          Push-Location $repo
+          try {
+            git fetch origin docs-versions 2>$null
+            $exists = $LASTEXITCODE -eq 0
+            if ($exists) {
+              git worktree add --force -B docs-versions $persist origin/docs-versions
+            }
+            else {
+              # Seed empty docs-versions branch (no historical trees yet)
+              git worktree add --force -B docs-versions $persist HEAD
+              Get-ChildItem -Force $persist |
+                Where-Object { $_.Name -notin @('.git') } |
+                Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          }
+          finally {
+            Pop-Location
+          }
+
+      - name: Merge version into docs-versions site
+        shell: pwsh
+        run: |
+          $version = "${{ steps.meta.outputs.version }}"
+          $channel = "${{ steps.meta.outputs.channel }}"
+          $line = "${{ steps.meta.outputs.line }}"
+          $built = Join-Path $env:GITHUB_WORKSPACE "built\v\$version"
+          $persist = Join-Path $env:GITHUB_WORKSPACE "docs-versions-site"
+          $dest = Join-Path $persist "v\$version"
+
+          if (-not (Test-Path (Join-Path $built 'index.html'))) {
+            throw "Built tree missing: $built"
+          }
+
+          New-Item -ItemType Directory -Force -Path (Join-Path $persist 'v') | Out-Null
+          if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+          Copy-Item -Recurse -Force $built $dest
+
+          $catalogArgs = @{
+            SiteRoot = $persist
+            Channel  = $channel
+            Version  = $version
+          }
+          if (-not [string]::IsNullOrWhiteSpace($line)) {
+            $catalogArgs['Line'] = $line
+          }
+          & "Standard-Toolkit-Online-Help/Scripts/Update-VersionsCatalog.ps1" @catalogArgs
+
+      - name: Commit and push docs-versions
+        shell: pwsh
+        run: |
+          $persist = Join-Path $env:GITHUB_WORKSPACE "docs-versions-site"
+          $version = "${{ steps.meta.outputs.version }}"
+          $channel = "${{ steps.meta.outputs.channel }}"
+          Push-Location $persist
+          try {
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            $status = git status --porcelain
+            if ([string]::IsNullOrWhiteSpace($status)) {
+              Write-Host "No site changes to commit."
+            }
+            else {
+              git commit -m "docs: publish $channel $version"
+              git push origin HEAD:docs-versions
+              if ($LASTEXITCODE -ne 0) { throw "Failed to push docs-versions" }
+            }
+          }
+          finally {
+            Pop-Location
+          }
+
+      - name: Stage Pages payload (no .git)
+        shell: pwsh
+        run: |
+          $persist = Join-Path $env:GITHUB_WORKSPACE "docs-versions-site"
+          $pages = Join-Path $env:GITHUB_WORKSPACE "pages-site"
+          if (Test-Path $pages) { Remove-Item -Recurse -Force $pages }
+          New-Item -ItemType Directory -Force -Path $pages | Out-Null
+          Get-ChildItem -Force $persist |
+            Where-Object { $_.Name -ne '.git' } |
+            ForEach-Object { Copy-Item -Recurse -Force $_.FullName (Join-Path $pages $_.Name) }
+          if (-not (Test-Path (Join-Path $pages 'versions.json'))) {
+            throw "pages-site missing versions.json"
+          }
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-site
+
+  deploy:
+    needs: publish
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/How to Build.md
+++ b/How to Build.md
@@ -3,19 +3,20 @@
 ## What
 
 - The help content is a combination of code trawling and MarkDown files.
-- Published output is a **multi-version** site: `/master/`, `/alpha/`, `/v105-lts/`, with `/` redirecting to `/master/`.
+- Published output is a **NuGet-versioned** site: `/v/<PackageVersion>/`, with `/` redirecting to the latest Stable version from `versions.json`.
 
 ---
 
 ## Automated Build (GitHub Actions)
 
-- The documentation is built by `.github/workflows/build.yml` on push/PR to main/master.
-- A matrix builds Standard + Extended API for toolkit branches `master`, `alpha`, and `V105-LTS` in parallel.
-- A merge job stitches the three trees, adds the root redirect, and deploys to GitHub Pages.
+- **Validation:** `.github/workflows/build.yml` builds a disposable `v/local-dev/` tree on push/PR (does not publish Pages).
+- **Publish:** `.github/workflows/publish-docs-version.yml` builds one NuGet version into the `docs-versions` branch and deploys GitHub Pages (triggered by `repository_dispatch` from Standard-Toolkit or manual `workflow_dispatch`).
 - To enable Pages:
   1. Go to your repository Settings → Pages
   2. Under "Source", select "GitHub Actions"
-  3. The documentation will be available at `https://<username>.github.io/<repository-name>/`
+  3. Docs URL: `https://<username>.github.io/<repository-name>/`
+
+See [Versions](Source/Help/DocFX/articles/Versions.md) and [Publish Docs From Toolkit](Source/Help/DocFX/articles/Contributing/Workflows/PublishDocsFromToolkit.md).
 
 ---
 
@@ -33,7 +34,7 @@
 
 - Edit the md file(s) [in the `DocFX\articles` subdirectory] to reflect the content, and add the pictures into the images directory.
 - If new content is added then update the `yml index` files.
-- Articles are **shared** across version trees; only API metadata changes per toolkit branch.
+- Articles are included in each version tree at publish time.
 
 ## API metadata (toolkit source)
 
@@ -44,11 +45,11 @@ DocFX extracts API reference from toolkit clones:
 
 **Local fast path:** sibling folders next to this repo (`../Standard-Toolkit/`, `../Extended-Toolkit/`).
 
-**Multi-version path:** `Scripts/Build-VersionedDocs.ps1` clones each branch under `.toolkit-src/` (gitignored) unless `-UseSiblings` is set.
+**Published version path:** `Scripts/Build-VersionedDocs.ps1 -Channel … -Version … -StandardRef …` checks out toolkits at those refs under `.toolkit-src/` unless `-UseSiblings` is set.
 
-Metadata is generated for **`net8.0-windows`** only (common TFM across master / alpha / V105-LTS). Both Standard and Extended metadata allow compilation errors so a broken module (or missing optional NuGet) does not abort the whole docs build. Extended skips Ultimate/Lite aggregates, tests, examples, and helper tools. Standard skips `TestForm` and `Krypton.Standard.Toolkit`. Unresolved article xrefs are warnings (see `rules` in `docfx.json`).
+Metadata is generated for **`net8.0-windows`**. Both Standard and Extended metadata allow compilation errors so a broken module does not abort the whole docs build. Extended skips Ultimate/Lite aggregates, tests, examples, and helper tools. Standard skips `TestForm` and `Krypton.Standard.Toolkit`. Unresolved article xrefs are warnings (see `rules` in `docfx.json`).
 
-DocFX cannot take a Git URL in `metadata.src`. GitHub Actions checks out both toolkits at the matrix branch beside this repo.
+DocFX cannot take a Git URL in `metadata.src`. CI checks out both toolkits beside this repo.
 
 ---
 
@@ -71,35 +72,26 @@ docfx docfx.json --serve
 
 View at [http://localhost:8080](http://localhost:8080).
 
-### Option 2: Build current siblings into `site/master`
+### Option 2: Build current siblings into `site/v/local-dev`
 
 ```cmd
 run.cmd build
 ```
 
-Output: `Source\Help\Output\site\master\` plus root redirect at `site\index.html`.
+Output: `Source\Help\Output\site\v\local-dev\` plus stub `versions.json` / root redirect.
 
-### Option 3: Build all versions (master, alpha, V105-LTS)
-
-```cmd
-run.cmd all
-```
-
-Or:
+### Option 3: Reproduce a published NuGet version
 
 ```powershell
-.\Scripts\Build-VersionedDocs.ps1 -All -OutputRoot Source\Help\Output\site
+.\Scripts\Build-VersionedDocs.ps1 `
+  -Channel stable `
+  -Version 110.26.11.328 `
+  -StandardRef <sha-or-tag> `
+  -ExtendedRef <sha-or-tag> `
+  -OutputRoot Source\Help\Output\site
 ```
 
-Output:
-
-```text
-Source/Help/Output/site/
-  index.html      → redirects to master/
-  master/
-  alpha/
-  v105-lts/
-```
+With `-UpdateCatalog`, also merges into `versions.json` and prunes old canary/nightly under that output root.
 
 ### Tip
 
@@ -119,3 +111,4 @@ Source/Help/Output/site/
 
 - [DocFX walkthrough overview](http://dotnet.github.io/docfx/tutorial/walkthrough/walkthrough_overview.html)
 - [Versions](Source/Help/DocFX/articles/Versions.md)
+- [Publish Docs From Toolkit](Source/Help/DocFX/articles/Contributing/Workflows/PublishDocsFromToolkit.md)

--- a/README.md
+++ b/README.md
@@ -10,27 +10,30 @@ Published site layout:
 
 | Path | Content |
 |------|---------|
-| `/` | Redirects to `/master/` |
-| `/master/` | Articles + Standard/Extended API from toolkit `master` |
-| `/alpha/` | Same layout from toolkit `alpha` |
-| `/v105-lts/` | Same layout from toolkit `V105-LTS` |
+| `/` | Redirects to latest Stable (`versions.json` → `default`) |
+| `/versions.json` | Catalog for the navbar version dropdown |
+| `/v/<PackageVersion>/` | Articles + Standard/Extended API for that NuGet version |
 
-Articles are shared across versions; API pages reflect the selected toolkit branch tip. Use the version dropdown in the site navbar to switch.
+Channels: **Stable** and **LTS** keep every published version; **Canary** and **Nightly** keep latest only. Dropdown labels are exact NuGet version strings.
 
-> **Note:** Bookmarks to the old root `/api/...` paths should use `/master/api/...` (or another version prefix) after this cutover.
+> **Note:** Older bookmarks to `/master/...`, `/alpha/...`, or `/v105-lts/...` should use `/v/<PackageVersion>/...` after the NuGet-aligned cutover.
 
 ## Automated Builds
 
-Documentation is automatically built and deployed using GitHub Actions:
-- Builds automatically on every push to main/master
-- Validates on pull requests
-- Builds `master`, `alpha`, and `V105-LTS` in parallel, then merges into one GitHub Pages site
+| Workflow | Role |
+|----------|------|
+| `.github/workflows/build.yml` | PR/push validation — disposable `v/local-dev/` only |
+| `.github/workflows/publish-docs-version.yml` | Publish one version to the `docs-versions` branch and deploy Pages |
 
-See [Setup Guide](.github/SETUP_GITHUB_PAGES.md) for configuration details.
+Publishing is triggered by `repository_dispatch` (`docs-publish`) from Standard-Toolkit after a NuGet push, or manually via **Actions → Publish Docs Version**.
+
+**Secret (in Standard-Toolkit):** a PAT with `actions:write` on this repo (e.g. `DOCS_DISPATCH_TOKEN`) so release workflows can dispatch. See [Publish Docs From Toolkit](Source/Help/DocFX/articles/Contributing/Workflows/PublishDocsFromToolkit.md).
+
+See [Setup Guide](.github/SETUP_GITHUB_PAGES.md) for Pages configuration.
 
 ## Local Development
 
-Local builds expect **sibling** clones of [Standard-Toolkit](https://github.com/Krypton-Suite/Standard-Toolkit) and [Extended-Toolkit](https://github.com/Krypton-Suite/Extended-Toolkit) at `../Standard-Toolkit/` and `../Extended-Toolkit/` (same parent folder as this repo). If a sibling is missing, `run.cmd` clones the GitHub repository there as a fallback.
+Local builds expect **sibling** clones of [Standard-Toolkit](https://github.com/Krypton-Suite/Standard-Toolkit) and [Extended-Toolkit](https://github.com/Krypton-Suite/Extended-Toolkit) at `../Standard-Toolkit/` and `../Extended-Toolkit/`. If a sibling is missing, `run.cmd` clones the GitHub repository there as a fallback.
 
 ```bash
 # Install DocFX
@@ -39,19 +42,20 @@ dotnet tool install -g docfx
 # Fast loop: serve docs from current sibling toolkit checkouts
 run.cmd
 
-# Build current siblings into Source/Help/Output/site/master/
+# Build current siblings into Source/Help/Output/site/v/local-dev/
 run.cmd build
-
-# Build all three versions (clones under .toolkit-src/ when not using siblings)
-run.cmd all
 ```
 
-Or with PowerShell directly:
+Or with PowerShell:
 
 ```powershell
-.\Scripts\Build-VersionedDocs.ps1 -All
-.\Scripts\Build-VersionedDocs.ps1 -Branch alpha
-.\Scripts\Build-VersionedDocs.ps1 -Branch master -UseSiblings -SkipClone -OutputRoot Source\Help\Output\site
+.\Scripts\Build-VersionedDocs.ps1 -LocalDev -UseSiblings -SkipClone -OutputRoot Source\Help\Output\site
+
+.\Scripts\Build-VersionedDocs.ps1 `
+  -Channel stable `
+  -Version 110.26.11.328 `
+  -StandardRef <sha-or-tag> `
+  -ExtendedRef <sha-or-tag>
 ```
 
-For more details, see [How to Build.md](How%20to%20Build.md).
+For more details, see [How to Build.md](How%20to%20Build.md) and [Versions](Source/Help/DocFX/articles/Versions.md).

--- a/Scripts/Build-VersionedDocs.ps1
+++ b/Scripts/Build-VersionedDocs.ps1
@@ -1,48 +1,76 @@
 <#
 .SYNOPSIS
-  Builds DocFX documentation for one or all toolkit branches (master, alpha, V105-LTS).
+  Builds DocFX documentation for a NuGet package version into v/<version>/.
 
 .DESCRIPTION
-  Each version is an isolated DocFX output tree under <OutputRoot>/<slug>/ so API UIDs
-  do not collide across branches.
+  Checks out Standard-Toolkit and Extended-Toolkit at the given refs (SHA/tag/branch),
+  builds a full DocFX tree under <OutputRoot>/v/<Version>/, and optionally updates
+  versions.json / root redirect when -UpdateCatalog is set.
 
   Do not pass DocFX --output together with build.dest — DocFX resolves {output}/{dest}.
-  This script patches build.output per version and runs DocFX without -o so HTML lands
-  in <OutputRoot>/<slug>/. Metadata YAML stays under DocFX/api and api-extended.
+  This script patches build.output per version and runs DocFX without -o.
 
-.PARAMETER Branch
-  Toolkit git branch: master | alpha | V105-LTS
+.PARAMETER Channel
+  stable | lts | canary | nightly
 
-.PARAMETER All
-  Build master, alpha, and V105-LTS into <OutputRoot>/<slug>/ and write a root redirect.
+.PARAMETER Version
+  Exact NuGet PackageVersion (e.g. 110.26.11.328 or 110.26.8.221-alpha).
+
+.PARAMETER StandardRef
+  Git SHA, tag, or branch of Standard-Toolkit for that package.
+
+.PARAMETER ExtendedRef
+  Matching Extended-Toolkit SHA/tag/branch (defaults to StandardRef).
+
+.PARAMETER Line
+  Optional LTS line name (e.g. V105-LTS) stored in versions.json.
+
+.PARAMETER LocalDev
+  Build current sibling checkouts into v/local-dev/ without cloning.
 
 .PARAMETER OutputRoot
-  Directory that receives version folders (default: Source/Help/Output/site).
+  Directory that receives v/<version>/ (default: Source/Help/Output/site).
 
 .PARAMETER UseSiblings
-  Use ../Standard-Toolkit and ../Extended-Toolkit as-is (CI / local current checkout).
-  When omitted, clones are kept under .toolkit-src/.
+  Use ../Standard-Toolkit and ../Extended-Toolkit as-is (CI / local).
 
 .PARAMETER SkipClone
-  Do not fetch/clone; require toolkit sources to already exist at the resolved paths.
+  Do not fetch/clone; require toolkit sources at the resolved paths.
+
+.PARAMETER UpdateCatalog
+  After a successful build, merge this version into versions.json and prune canary/nightly.
 
 .PARAMETER DocfxPath
   Path to docfx.exe (default: ~/.dotnet/tools/docfx.exe).
 #>
-[CmdletBinding(DefaultParameterSetName = 'Branch')]
+[CmdletBinding(DefaultParameterSetName = 'Publish')]
 param(
-    [Parameter(ParameterSetName = 'Branch')]
-    [ValidateSet('master', 'alpha', 'V105-LTS')]
-    [string] $Branch = 'master',
+    [Parameter(ParameterSetName = 'Publish', Mandatory = $true)]
+    [ValidateSet('stable', 'lts', 'canary', 'nightly')]
+    [string] $Channel,
 
-    [Parameter(ParameterSetName = 'All')]
-    [switch] $All,
+    [Parameter(ParameterSetName = 'Publish', Mandatory = $true)]
+    [string] $Version,
+
+    [Parameter(ParameterSetName = 'Publish')]
+    [string] $StandardRef,
+
+    [Parameter(ParameterSetName = 'Publish')]
+    [string] $ExtendedRef,
+
+    [Parameter(ParameterSetName = 'Publish')]
+    [string] $Line,
+
+    [Parameter(ParameterSetName = 'LocalDev')]
+    [switch] $LocalDev,
 
     [string] $OutputRoot,
 
     [switch] $UseSiblings,
 
     [switch] $SkipClone,
+
+    [switch] $UpdateCatalog,
 
     [string] $DocfxPath
 )
@@ -73,14 +101,29 @@ if (-not (Test-Path $DocfxPath)) {
     $DocfxPath = Join-Path $env:USERPROFILE '.dotnet\tools\docfx.exe'
 }
 
-function Get-VersionSlug {
-    param([string] $GitBranch)
-    switch ($GitBranch) {
-        'master'   { 'master' }
-        'alpha'    { 'alpha' }
-        'V105-LTS' { 'v105-lts' }
-        default    { throw "Unsupported branch: $GitBranch" }
+if ($LocalDev) {
+    $Channel = 'stable'
+    $Version = 'local-dev'
+    $UseSiblings = $true
+    $SkipClone = $true
+    $UpdateCatalog = $false
+}
+else {
+    if (-not $StandardRef) {
+        throw 'StandardRef is required unless -LocalDev is set.'
     }
+    if (-not $ExtendedRef) {
+        $ExtendedRef = $StandardRef
+    }
+}
+
+# Folder segment under v/ — keep NuGet version chars (letters, digits, ., -)
+function Get-VersionFolderName {
+    param([string] $PackageVersion)
+    if ($PackageVersion -notmatch '^[A-Za-z0-9._-]+$') {
+        throw "Version contains characters unsafe for a URL path segment: $PackageVersion"
+    }
+    return $PackageVersion
 }
 
 function Get-RelativeUnixPath {
@@ -95,11 +138,11 @@ function Get-RelativeUnixPath {
     return ($rel -replace '\\', '/').TrimEnd('/') + '/'
 }
 
-function Ensure-ToolkitClone {
+function Ensure-ToolkitAtRef {
     param(
         [string] $Name,
         [string] $RepoUrl,
-        [string] $GitBranch,
+        [string] $GitRef,
         [string] $DestPath,
         [string] $MarkerRelativePath
     )
@@ -113,20 +156,28 @@ function Ensure-ToolkitClone {
     }
 
     if (-not (Test-Path (Join-Path $DestPath '.git'))) {
-        Write-Host "[INFO] Cloning $Name ($GitBranch) into $DestPath ..."
+        Write-Host "[INFO] Cloning $Name into $DestPath ..."
         New-Item -ItemType Directory -Force -Path (Split-Path $DestPath -Parent) | Out-Null
-        git clone --branch $GitBranch --single-branch --depth 1 $RepoUrl $DestPath
+        git clone --filter=blob:none --no-checkout $RepoUrl $DestPath
         if ($LASTEXITCODE -ne 0) { throw "Failed to clone $Name." }
-        return
     }
 
-    Write-Host "[INFO] Updating $Name at $DestPath to $GitBranch ..."
+    Write-Host "[INFO] Checking out $Name @ $GitRef ..."
     Push-Location $DestPath
     try {
-        git fetch --depth 1 origin $GitBranch
-        if ($LASTEXITCODE -ne 0) { throw "Failed to fetch $Name ($GitBranch)." }
-        git checkout -B $GitBranch FETCH_HEAD
-        if ($LASTEXITCODE -ne 0) { throw "Failed to checkout $Name ($GitBranch)." }
+        git fetch --depth 1 origin $GitRef
+        if ($LASTEXITCODE -ne 0) {
+            # Full fetch for tags/SHAs that shallow fetch may miss
+            git fetch --tags origin
+            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch $Name ($GitRef)." }
+            git fetch origin $GitRef
+            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch $Name ($GitRef)." }
+        }
+        git checkout --force FETCH_HEAD
+        if ($LASTEXITCODE -ne 0) {
+            git checkout --force $GitRef
+            if ($LASTEXITCODE -ne 0) { throw "Failed to checkout $Name ($GitRef)." }
+        }
     }
     finally {
         Pop-Location
@@ -192,15 +243,18 @@ function Assert-VersionOutput {
 
 function Build-OneVersion {
     param(
-        [string] $GitBranch,
-        [string] $Slug
+        [string] $FolderName,
+        [string] $StdRef,
+        [string] $ExtRef
     )
 
     Write-Host "============================================"
-    Write-Host " Building documentation for $GitBranch -> $Slug"
+    Write-Host " Building documentation -> v/$FolderName"
+    Write-Host " Channel=$Channel Version=$Version"
     Write-Host "============================================"
 
     $patchSrc = $false
+    $safeKey = ($FolderName -replace '[^A-Za-z0-9._-]', '_')
     if ($UseSiblings) {
         $parent = Split-Path $RepoRoot -Parent
         $standardRoot = Join-Path $parent 'Standard-Toolkit'
@@ -215,28 +269,28 @@ function Build-OneVersion {
         Write-Host "[INFO] Using sibling Extended-Toolkit: $extendedRoot"
     }
     else {
-        $standardRoot = Join-Path $ToolkitSrcRoot "Standard-Toolkit-$Slug"
-        $extendedRoot = Join-Path $ToolkitSrcRoot "Extended-Toolkit-$Slug"
-        Ensure-ToolkitClone -Name 'Standard-Toolkit' `
+        $standardRoot = Join-Path $ToolkitSrcRoot "Standard-Toolkit-$safeKey"
+        $extendedRoot = Join-Path $ToolkitSrcRoot "Extended-Toolkit-$safeKey"
+        Ensure-ToolkitAtRef -Name 'Standard-Toolkit' `
             -RepoUrl 'https://github.com/Krypton-Suite/Standard-Toolkit.git' `
-            -GitBranch $GitBranch `
+            -GitRef $StdRef `
             -DestPath $standardRoot `
             -MarkerRelativePath 'Source\Krypton Components'
-        Ensure-ToolkitClone -Name 'Extended-Toolkit' `
+        Ensure-ToolkitAtRef -Name 'Extended-Toolkit' `
             -RepoUrl 'https://github.com/Krypton-Suite/Extended-Toolkit.git' `
-            -GitBranch $GitBranch `
+            -GitRef $ExtRef `
             -DestPath $extendedRoot `
             -MarkerRelativePath 'Source\Krypton Toolkit'
         $patchSrc = $true
     }
 
-    $versionOut = Join-Path $OutputRoot $Slug
+    $versionOut = Join-Path $OutputRoot "v\$FolderName"
     if (Test-Path $versionOut) {
         Remove-Item -Recurse -Force $versionOut
     }
     New-Item -ItemType Directory -Force -Path $versionOut | Out-Null
 
-    $tempConfig = Join-Path $DocfxDir "docfx.$Slug.json"
+    $tempConfig = Join-Path $DocfxDir ("docfx.{0}.json" -f $safeKey)
     Write-VersionConfig `
         -BuildOutput $versionOut `
         -DestConfigPath $tempConfig `
@@ -250,7 +304,7 @@ function Build-OneVersion {
         Write-Host "[INFO] Config: $tempConfig"
         & $DocfxPath $tempConfig
         if ($LASTEXITCODE -ne 0) {
-            throw "DocFX failed for $GitBranch (exit $LASTEXITCODE)."
+            throw "DocFX failed for $Version (exit $LASTEXITCODE)."
         }
     }
     finally {
@@ -263,29 +317,33 @@ function Build-OneVersion {
     Assert-VersionOutput -VersionOut $versionOut
 }
 
-function Write-RootRedirect {
-    param([string] $SiteRoot)
-
-    $template = Join-Path $PSScriptRoot 'root-redirect.index.html'
-    $indexPath = Join-Path $SiteRoot 'index.html'
-    Copy-Item -Force -Path $template -Destination $indexPath
-    Write-Host "[INFO] Wrote root redirect: $indexPath"
-}
-
 # --- main ---
 New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $OutputRoot 'v') | Out-Null
 
-if ($All) {
-    foreach ($b in @('master', 'alpha', 'V105-LTS')) {
-        Build-OneVersion -GitBranch $b -Slug (Get-VersionSlug $b)
+$folderName = Get-VersionFolderName -PackageVersion $Version
+Build-OneVersion -FolderName $folderName -StdRef $StandardRef -ExtRef $ExtendedRef
+
+if ($UpdateCatalog) {
+    $catalogArgs = @{
+        SiteRoot = $OutputRoot
+        Channel  = $Channel
+        Version  = $Version
     }
-    Write-RootRedirect -SiteRoot $OutputRoot
+    if ($Line) { $catalogArgs['Line'] = $Line }
+    & (Join-Path $PSScriptRoot 'Update-VersionsCatalog.ps1') @catalogArgs
 }
 else {
-    Build-OneVersion -GitBranch $Branch -Slug (Get-VersionSlug $Branch)
-    if (-not $UseSiblings) {
-        Write-RootRedirect -SiteRoot $OutputRoot
+    $templateRedirect = Join-Path $PSScriptRoot 'root-redirect.index.html'
+    $indexPath = Join-Path $OutputRoot 'index.html'
+    if (-not (Test-Path $indexPath) -and (Test-Path $templateRedirect)) {
+        Copy-Item -Force $templateRedirect $indexPath
+    }
+    $templateCatalog = Join-Path $PSScriptRoot 'site-templates\versions.json'
+    $catalogPath = Join-Path $OutputRoot 'versions.json'
+    if (-not (Test-Path $catalogPath) -and (Test-Path $templateCatalog)) {
+        Copy-Item -Force $templateCatalog $catalogPath
     }
 }
 
-Write-Host "[INFO] Done. Output: $OutputRoot"
+Write-Host "[INFO] Done. Output: $OutputRoot\v\$folderName"

--- a/Scripts/Update-VersionsCatalog.ps1
+++ b/Scripts/Update-VersionsCatalog.ps1
@@ -1,0 +1,148 @@
+<#
+.SYNOPSIS
+  Updates versions.json and root index.html after a docs version is published.
+
+.PARAMETER SiteRoot
+  Root of the assembled docs site (contains versions.json and v/).
+
+.PARAMETER Channel
+  stable | lts | canary | nightly
+
+.PARAMETER Version
+  Exact NuGet PackageVersion string.
+
+.PARAMETER Line
+  Optional LTS line name (e.g. V105-LTS).
+
+.PARAMETER PackageId
+  Optional override for packageId in the catalog entry.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $SiteRoot,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('stable', 'lts', 'canary', 'nightly')]
+    [string] $Channel,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Version,
+
+    [string] $Line,
+
+    [string] $PackageId
+)
+
+$ErrorActionPreference = 'Stop'
+
+$SiteRoot = [System.IO.Path]::GetFullPath($SiteRoot)
+$catalogPath = Join-Path $SiteRoot 'versions.json'
+$templateCatalog = Join-Path $PSScriptRoot 'site-templates\versions.json'
+
+if (-not (Test-Path $catalogPath)) {
+    if (Test-Path $templateCatalog) {
+        Copy-Item -Force $templateCatalog $catalogPath
+    }
+    else {
+        throw "Missing versions.json at $catalogPath"
+    }
+}
+
+$packageIds = @{
+    stable  = 'Krypton.Standard.Toolkit'
+    lts     = 'Krypton.Standard.Toolkit'
+    canary  = 'Krypton.Standard.Toolkit.Canary'
+    nightly = 'Krypton.Standard.Toolkit.Nightly'
+}
+
+if (-not $PackageId) {
+    $PackageId = $packageIds[$Channel]
+}
+
+$path = ('v/{0}/' -f $Version)
+$entry = [pscustomobject]@{
+    version   = $Version
+    path      = $path
+    packageId = $PackageId
+}
+if ($Line) {
+    $entry | Add-Member -NotePropertyName line -NotePropertyValue $Line
+}
+
+$catalog = Get-Content -Raw -Path $catalogPath | ConvertFrom-Json
+
+# Normalize channel lists (ConvertFrom-Json turns [] into $null on Windows PowerShell)
+$channelMap = @{
+    stable  = @()
+    lts     = @()
+    canary  = @()
+    nightly = @()
+}
+foreach ($name in @('stable', 'lts', 'canary', 'nightly')) {
+    $raw = $catalog.channels.$name
+    if ($null -ne $raw) {
+        $channelMap[$name] = @($raw)
+    }
+}
+
+$existing = @($channelMap[$Channel])
+
+# Prune canary/nightly: remove other version trees and catalog entries
+if ($Channel -in @('canary', 'nightly')) {
+    foreach ($old in $existing) {
+        if ($old.version -eq $Version) { continue }
+        $rel = [string]$old.path
+        $oldDir = Join-Path $SiteRoot ($rel.TrimEnd('/').Replace('/', [IO.Path]::DirectorySeparatorChar))
+        if (Test-Path $oldDir) {
+            Write-Host "[INFO] Pruning previous $Channel docs: $oldDir"
+            Remove-Item -Recurse -Force $oldDir
+        }
+    }
+    $existing = @()
+}
+
+# Upsert current version at front of channel list
+$filtered = @($existing | Where-Object { $_.version -ne $Version })
+$channelMap[$Channel] = @($entry) + $filtered
+
+# Rebuild channels object for JSON
+$catalog.channels = [pscustomobject]@{
+    stable  = @($channelMap['stable'])
+    lts     = @($channelMap['lts'])
+    canary  = @($channelMap['canary'])
+    nightly = @($channelMap['nightly'])
+}
+
+# Default = newest stable if any; else keep existing / current version
+$stableList = @($channelMap['stable'])
+if ($stableList.Length -gt 0) {
+    $catalog.default = $stableList[0].version
+}
+elseif ([string]::IsNullOrWhiteSpace([string]$catalog.default)) {
+    $catalog.default = $Version
+}
+
+$json = $catalog | ConvertTo-Json -Depth 10
+[System.IO.File]::WriteAllText($catalogPath, $json)
+Write-Host "[INFO] Updated catalog: $catalogPath (default=$($catalog.default))"
+
+$target = 'v/' + $catalog.default + '/'
+$indexPath = Join-Path $SiteRoot 'index.html'
+$html = @"
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=$target" />
+  <title>Krypton Toolkit Documentation</title>
+  <link rel="canonical" href="$target" />
+  <script>location.replace("$target");</script>
+</head>
+<body>
+  <p>Redirecting to <a href="$target">$($catalog.default)</a> documentation…</p>
+</body>
+</html>
+"@
+[System.IO.File]::WriteAllText($indexPath, $html)
+Write-Host "[INFO] Wrote root redirect -> $target"

--- a/Scripts/root-redirect.index.html
+++ b/Scripts/root-redirect.index.html
@@ -2,12 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta http-equiv="refresh" content="0; url=master/" />
+  <meta http-equiv="refresh" content="0; url=versions.json" />
   <title>Krypton Toolkit Documentation</title>
-  <link rel="canonical" href="master/" />
-  <script>location.replace("master/");</script>
+  <script>
+    fetch("versions.json")
+      .then(function (r) { return r.json(); })
+      .then(function (v) {
+        var target = v.default ? ("v/" + v.default + "/") : null;
+        if (target) location.replace(target);
+      })
+      .catch(function () { /* versions.json missing until first publish */ });
+  </script>
 </head>
 <body>
-  <p>Redirecting to <a href="master/">master</a> documentation…</p>
+  <p>Loading documentation versions… If this page does not redirect, no Stable docs version has been published yet.</p>
 </body>
 </html>

--- a/Scripts/site-templates/versions.json
+++ b/Scripts/site-templates/versions.json
@@ -1,0 +1,9 @@
+{
+  "default": null,
+  "channels": {
+    "stable": [],
+    "lts": [],
+    "canary": [],
+    "nightly": []
+  }
+}

--- a/Source/Help/DocFX/articles/Contributing/Workflows/PublishDocsFromToolkit.md
+++ b/Source/Help/DocFX/articles/Contributing/Workflows/PublishDocsFromToolkit.md
@@ -1,0 +1,85 @@
+# Publishing docs from toolkit releases
+
+Online Help trees are aligned to **NuGet `PackageVersion`**, not live branch tips. After a successful package push in [Standard-Toolkit](https://github.com/Krypton-Suite/Standard-Toolkit), that repo should notify this repository so a matching DocFX tree is built and kept under `/v/<version>/`.
+
+## Online-Help workflow
+
+Workflow: `.github/workflows/publish-docs-version.yml` in this repository.
+
+| Trigger | When |
+|---------|------|
+| `repository_dispatch` type `docs-publish` | Automated from Standard-Toolkit after NuGet push |
+| `workflow_dispatch` | Manual backfill / until the dispatch hook lands |
+
+### Payload / inputs
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `channel` | yes | `stable` \| `lts` \| `canary` \| `nightly` |
+| `version` | yes | Exact NuGet `PackageVersion` (e.g. `110.26.11.328`, `110.26.8.221-alpha`) |
+| `standard_ref` | yes | Git SHA or tag of Standard-Toolkit used for that package |
+| `extended_ref` | no | Matching Extended-Toolkit SHA/tag (defaults to `standard_ref`) |
+| `line` | no | LTS line name when `channel=lts` (e.g. `V105-LTS`) |
+
+Example `client_payload` for `repository_dispatch`:
+
+```json
+{
+  "channel": "stable",
+  "version": "110.26.11.328",
+  "standard_ref": "abc123def456...",
+  "extended_ref": "fed654cba321...",
+  "line": ""
+}
+```
+
+Retention: every **Stable** and **LTS** tree is kept; **Canary** and **Nightly** keep only the latest tree of that channel. Persistence uses the `docs-versions` branch in this repo.
+
+## Companion change in Standard-Toolkit (required for automation)
+
+Implement in Standard-Toolkit `release.yml` / `nightly.yml` (and Canary/LTS release workflows) **after** a successful NuGet push:
+
+1. Resolve `PackageVersion`, commit SHA used for the pack, and channel.
+2. Resolve the matching Extended-Toolkit ref at publish time.
+3. Call GitHub API `repository_dispatch` against `Krypton-Suite/Standard-Toolkit-Online-Help` with `event_type: docs-publish` and the payload above.
+
+### Secret
+
+Create a fine-grained PAT (or classic PAT) with **`actions: write`** (and contents read if needed) on **Standard-Toolkit-Online-Help**, and store it in Standard-Toolkit as e.g. `DOCS_DISPATCH_TOKEN` (or `ONLINE_HELP_DISPATCH_TOKEN`).
+
+Example step (illustrative — adapt to existing workflows):
+
+```yaml
+- name: Trigger Online-Help docs publish
+  env:
+    GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+  run: |
+    gh api repos/Krypton-Suite/Standard-Toolkit-Online-Help/dispatches \
+      -f event_type='docs-publish' \
+      -f 'client_payload[channel]=stable' \
+      -f "client_payload[version]=${{ env.PACKAGE_VERSION }}" \
+      -f "client_payload[standard_ref]=${{ github.sha }}" \
+      -f "client_payload[extended_ref]=${{ env.EXTENDED_REF }}"
+```
+
+Until that PR lands, use this repo’s **Publish Docs Version** workflow manually after each NuGet publish.
+
+## Local reproduction
+
+```powershell
+.\Scripts\Build-VersionedDocs.ps1 `
+  -Channel stable `
+  -Version 110.26.11.328 `
+  -StandardRef <sha-or-tag> `
+  -ExtendedRef <sha-or-tag> `
+  -UpdateCatalog `
+  -OutputRoot Source\Help\Output\site
+```
+
+Dev-only siblings (does not update the published catalog):
+
+```cmd
+run.cmd build
+```
+
+Builds into `Source\Help\Output\site\v\local-dev\`.

--- a/Source/Help/DocFX/articles/Versions.md
+++ b/Source/Help/DocFX/articles/Versions.md
@@ -1,13 +1,36 @@
 # Documentation versions
 
-This site publishes a separate documentation tree for each supported toolkit branch tip:
+This site publishes a separate documentation tree for each **NuGet package version** that has been released. Trees live under `/v/<PackageVersion>/`. The site root redirects to the latest **Stable** version listed in `versions.json`.
 
-| Version | Path | Toolkit branches |
-|---------|------|------------------|
-| **Master** (default) | `/master/` | `Standard-Toolkit` + `Extended-Toolkit` @ `master` |
-| **Alpha** | `/alpha/` | @ `alpha` |
-| **V105-LTS** | `/v105-lts/` | @ `V105-LTS` |
+## Channels and retention
 
-Conceptual articles are shared across versions. API reference pages reflect the selected branch.
+| Channel | Typical package id | Path example | Retention |
+|---------|-------------------|--------------|-----------|
+| **Stable** | `Krypton.Standard.Toolkit` | `/v/110.26.11.328/` | Keep every published version |
+| **LTS** | `Krypton.Standard.Toolkit` (from an LTS line, e.g. `V105-LTS`) | `/v/105.25.11.310/` | Keep every published version |
+| **Canary** | `Krypton.Standard.Toolkit.Canary` | `/v/110.26.6.173-beta/` | Latest only |
+| **Nightly** | `Krypton.Standard.Toolkit.Nightly` | `/v/110.26.8.221-alpha/` | Latest only |
 
-Use the version dropdown in the top navigation to switch trees. The site root redirects to `/master/`.
+Dropdown labels use the **exact NuGet version string** (same as on nuget.org), grouped by channel. LTS entries may also record a `line` (e.g. `V105-LTS`); new LTS lines are added when those packages are published—nothing is hard-coded to a single LTS branch name.
+
+## Site layout
+
+```text
+/
+  index.html       → redirect to latest Stable
+  versions.json    → catalog for the navbar dropdown
+  v/<version>/     → full DocFX tree (articles + api + api-extended)
+```
+
+Conceptual articles are baked into each version tree at publish time. API pages reflect the toolkit sources at the SHA used for that NuGet package.
+
+## How versions are published
+
+1. A Stable / LTS / Canary / Nightly NuGet publish in **Standard-Toolkit** (or a manual `workflow_dispatch`) triggers `publish-docs-version.yml` in this repo.
+2. DocFX builds against the release `standard_ref` / `extended_ref`.
+3. Output is merged into the long-lived `docs-versions` branch (`v/<version>/`), old Canary/Nightly trees are pruned, and `versions.json` is updated.
+4. That branch tree is deployed to GitHub Pages.
+
+Until Standard-Toolkit emits `repository_dispatch` (`docs-publish`), use **Actions → Publish Docs Version** with channel, version, and git refs. See [Publishing docs from toolkit releases](Contributing/Workflows/PublishDocsFromToolkit.md).
+
+Pushes and PRs to this repo only **validate** a disposable `v/local-dev/` build; they do not publish version trees.

--- a/Source/Help/DocFX/articles/toc.yml
+++ b/Source/Help/DocFX/articles/toc.yml
@@ -599,6 +599,8 @@
           href: Contributing/Workflows/NightlyWorkflow.md
         - name: PR Branch Policy Workflow
           href: Contributing/Workflows/PRBranchPolicyWorkflow.md
+        - name: Publish Docs From Toolkit Releases
+          href: Contributing/Workflows/PublishDocsFromToolkit.md
         - name: Release Candidate NuGet Packages Workflow
           href: Contributing/Workflows/RCNuGetPackages.md
         - name: Release Workflow

--- a/Source/Help/DocFX/docfx-tmpl/src/styles/main.js
+++ b/Source/Help/DocFX/docfx-tmpl/src/styles/main.js
@@ -57,42 +57,91 @@ $(function () {
 })
 
 document.addEventListener("DOMContentLoaded", () => {
-  // Version switcher for multi-branch sites (/master/, /alpha/, /v105-lts/)
+  // Version switcher: loads /versions.json (NuGet package versions by channel)
   (function insertVersionSwitcher() {
-    const versions = [
-      { slug: "master", label: "Master" },
-      { slug: "alpha", label: "Alpha" },
-      { slug: "v105-lts", label: "V105-LTS" }
-    ];
-    const match = location.pathname.match(/^(.*\/)?(master|alpha|v105-lts)(\/|$)/i);
+    const match = location.pathname.match(/^(.*\/)?v\/([^/]+)(\/|$)/i);
     if (!match) {
       return;
     }
     const prefix = match[1] || "/";
-    const current = match[2].toLowerCase();
+    const current = decodeURIComponent(match[2]);
+    const pageSuffix = location.pathname.slice(match[0].length);
     const nav = document.querySelector(".navbar-nav") || document.querySelector("header nav ul");
     if (!nav) {
       return;
     }
-    const li = document.createElement("li");
-    li.className = "krypton-version-switcher";
-    const select = document.createElement("select");
-    select.setAttribute("aria-label", "Documentation version");
-    select.title = "Toolkit branch for API docs";
-    versions.forEach((v) => {
-      const opt = document.createElement("option");
-      opt.value = prefix + v.slug + "/";
-      opt.textContent = v.label;
-      if (v.slug === current) {
-        opt.selected = true;
-      }
-      select.appendChild(opt);
-    });
-    select.addEventListener("change", () => {
-      location.href = select.value;
-    });
-    li.appendChild(select);
-    nav.appendChild(li);
+
+    function siteRootFromPrefix(p) {
+      // prefix is everything before "v/<version>/", e.g. "/Standard-Toolkit-Online-Help/"
+      return p;
+    }
+
+    const root = siteRootFromPrefix(prefix);
+    const catalogUrl = root + "versions.json";
+
+    fetch(catalogUrl)
+      .then((r) => {
+        if (!r.ok) throw new Error("versions.json " + r.status);
+        return r.json();
+      })
+      .then((catalog) => {
+        const channelOrder = [
+          { key: "stable", label: "Stable" },
+          { key: "lts", label: "LTS" },
+          { key: "canary", label: "Canary" },
+          { key: "nightly", label: "Nightly" }
+        ];
+        const li = document.createElement("li");
+        li.className = "krypton-version-switcher";
+        const select = document.createElement("select");
+        select.setAttribute("aria-label", "Documentation version");
+        select.title = "NuGet package version for API docs";
+
+        channelOrder.forEach((ch) => {
+          const entries = (catalog.channels && catalog.channels[ch.key]) || [];
+          if (!entries.length) return;
+          const group = document.createElement("optgroup");
+          group.label = ch.label;
+          entries.forEach((entry) => {
+            const opt = document.createElement("option");
+            const versionPath = (entry.path || ("v/" + entry.version + "/")).replace(/^\//, "");
+            opt.value = root + versionPath;
+            opt.textContent = entry.version;
+            opt.dataset.version = entry.version;
+            if (entry.version === current) {
+              opt.selected = true;
+            }
+            group.appendChild(opt);
+          });
+          select.appendChild(group);
+        });
+
+        if (!select.options.length) {
+          return;
+        }
+
+        select.addEventListener("change", () => {
+          const base = select.value.endsWith("/") ? select.value : select.value + "/";
+          if (!pageSuffix) {
+            location.href = base;
+            return;
+          }
+          const candidate = base + pageSuffix;
+          fetch(candidate, { method: "GET", cache: "no-store" })
+            .then((r) => {
+              location.href = r.ok ? candidate : base;
+            })
+            .catch(() => {
+              location.href = base;
+            });
+        });
+
+        li.appendChild(select);
+        nav.appendChild(li);
+      })
+      .catch(() => {
+        /* catalog missing on local single-tree builds */
+      });
   })();
 
   document.querySelectorAll("pre > code").forEach((codeBlock) => {

--- a/run.cmd
+++ b/run.cmd
@@ -46,19 +46,6 @@ if not exist "%DOCFX_CONFIG%" (
 )
 
 REM ============================================
-REM Multi-version build: run.cmd all
-REM ============================================
-if /I "%MODE%"=="all" (
-    echo [INFO] Building master, alpha, and V105-LTS into "%SITE_ROOT%"
-    powershell -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%Scripts\Build-VersionedDocs.ps1" -All -OutputRoot "%SITE_ROOT%"
-    if errorlevel 1 exit /b 1
-    echo [INFO] Multi-version site ready at "%SITE_ROOT%"
-    echo [INFO] Open "%SITE_ROOT%\index.html" or serve that folder with DocFX/any static server.
-    endlocal
-    exit /b 0
-)
-
-REM ============================================
 REM Ensure sibling toolkit sources
 REM DocFX metadata.src cannot use a Git URL, so clone
 REM the sibling folder from GitHub when it is missing.
@@ -69,22 +56,28 @@ call :EnsureSiblingToolkit "Extended-Toolkit" "%EXTENDED_TOOLKIT_ROOT%" "%EXTEND
 if errorlevel 1 exit /b 1
 
 REM ============================================
-REM Single-version build into site/master (default local layout)
+REM Dev build into site/v/local-dev (does not touch docs-versions)
 REM ============================================
 if /I "%MODE%"=="build" (
-    echo [INFO] Building current siblings into "%SITE_ROOT%\master"
-    powershell -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%Scripts\Build-VersionedDocs.ps1" -Branch master -OutputRoot "%SITE_ROOT%" -UseSiblings -SkipClone
+    echo [INFO] Building current siblings into "%SITE_ROOT%\v\local-dev"
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%REPO_ROOT%Scripts\Build-VersionedDocs.ps1" -LocalDev -OutputRoot "%SITE_ROOT%" -UseSiblings -SkipClone
     if errorlevel 1 exit /b 1
-    copy /Y "%REPO_ROOT%Scripts\root-redirect.index.html" "%SITE_ROOT%\index.html" >nul
     endlocal
     exit /b 0
+)
+
+if /I "%MODE%"=="all" (
+    echo [INFO] "run.cmd all" is deprecated. Use Build-VersionedDocs.ps1 -Channel/-Version/-StandardRef for NuGet versions,
+    echo [INFO] or "run.cmd build" for a local-dev tree. See articles\Versions.md
+    endlocal
+    exit /b 1
 )
 
 REM ============================================
 REM Start DocFX (serve current siblings; classic Output path)
 REM ============================================
 echo [INFO] Starting DocFX server (current sibling toolkits)...
-echo [INFO] Tip: use "run.cmd all" for master/alpha/V105-LTS trees under Output\site\
+echo [INFO] Tip: use "run.cmd build" for v\local-dev under Output\site\
 
 start "" "%DOCFX%" "%DOCFX_CONFIG%" --serve
 


### PR DESCRIPTION
Replace branch-based multi-version site with NuGet-aligned versioning. Add publish workflow (publish-docs-version.yml) driven by repository_dispatch/workflow_dispatch to build a single v/<version>/ tree, merge into docs-versions branch, update versions.json, prune canary/nightly, and deploy Pages. Change build.yml to a PR/push validation job that builds disposable v/local-dev only (no Pages deploy). Rewrite Scripts/Build-VersionedDocs.ps1 to support Channel/Version/StandardRef/ExtendedRef, LocalDev mode, and UpdateCatalog; add Update-VersionsCatalog.ps1 and a versions.json template. Update root redirect, site JS (version switcher), docs, README, run.cmd, and TOC; add documentation on publish-from-toolkit workflow. Overall: implement NuGet-versioned publishing and validation flow, update tooling and docs accordingly.